### PR TITLE
closure-compiler gemを< 1.1.11に制限

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'haml', '~> 4.0'
 gem 'sass', '~> 3.2'
 gem 'compass'
 gem 'bootstrap-sass', ['~> 3.2', '!= 3.3.5']  # 3.3.5 has dependency problem
-gem 'closure-compiler', '~> 1.1'
+gem 'closure-compiler', '~> 1.1', '< 1.1.11' # from 1.1.11 requires JDK1.8
 
 gem 'net-ldap'
 gem 'smbhash'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
     chunky_png (1.3.4)
-    closure-compiler (1.1.11)
+    closure-compiler (1.1.10)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -81,7 +81,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootstrap-sass (~> 3.2, != 3.3.5)
-  closure-compiler (~> 1.1)
+  closure-compiler (~> 1.1, < 1.1.11)
   compass
   haml (~> 4.0)
   net-ldap


### PR DESCRIPTION
1.1.11からJava7向けにコンパイルされたJarが同梱されるようになったため．
