### PR TITLE
ソートのときに数値を数値としてソートする

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -66,7 +66,7 @@ module GuildBook
 
       users = user_repo.search(params['q'], params['all']).sort do |u, v|
         sort_keys.inject(0) do |x, (key, ord)|
-          x.nonzero? || (u[key] <=> v[key]) * ord
+          x.nonzero? || (u[key].map(&Utils.method(:tokenize)) <=> v[key].map(&Utils.method(:tokenize))) * ord
         end
       end
 

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -4,6 +4,10 @@ module GuildBook
       def parse_sortkeys(s)
         s.split(',').map {|key| key[0] != '-' ? [key, 1] : [key[1..-1], -1] }
       end
+
+      def tokenize(s)
+        s.split(/(\d+)|\s+/).map {|t| t =~ /\A\d+\z/ ? t.to_i : t }
+      end
     end
   end
 end


### PR DESCRIPTION
UIDの桁数を増やしたらユーザ一覧が綺麗に並ばなくなってしまった．

行をソートする際に文字列から数値っぽいところを抜き出して，特別扱いしてならべるようにします．
