### PR TITLE
AddUserプラグインのログイン名入力欄にフォーマットの制約をつける

### DIFF
--- a/views/adduser.haml
+++ b/views/adduser.haml
@@ -10,7 +10,7 @@
         ログイン名
         %span.form-required *
       %div.col-sm-5.col-xs-6
-        %input.form-control{name: '$uid', value: uid, placeholder: 'combat'}
+        %input.form-control{name: '$uid', value: uid, required: true, pattern: '^[a-z][a-z0-9]{2,7}$', placeholder: 'combat'}
     %div.row
       %div.col-sm-2.col-xs-12
         氏名(ローマ字)


### PR DESCRIPTION
ログイン名の制約を満たしていないことが，送信前にわかるようにします．