### PR TITLE
Checklistプラグイン: 学年が/B\d+/で始まる人も学部生扱いする

### DIFF
--- a/lib/plugins/checklist_helpers.rb
+++ b/lib/plugins/checklist_helpers.rb
@@ -11,11 +11,11 @@ module GuildBook
 
       def student?(u)
         status = u['x-kmc-UniversityStatus'].first
-        status and status =~/^(?:M|D)?\d+$/
+        status and status =~/^[BMD]?\d+$/
       end
 
       def parse_grade(g)
-        return [:u, $1.to_i] if g =~ /^(\d+)$/
+        return [:u, $1.to_i] if g =~ /^B?(\d+)$/
         return [:m, $1.to_i] if g =~ /^M(\d+)$/
         return [:d, $1.to_i] if g =~ /^D(\d+)$/
         return [:o, 0]


### PR DESCRIPTION
"B4"などがOB扱いされるのはよろしくない