### PR TITLE
Fix indent in textarea

### DIFF
--- a/views/edit.haml
+++ b/views/edit.haml
@@ -97,7 +97,7 @@
         SSH 公開鍵
       %div.col-sm-10.col-xs-12
         / Content must be on the same line to suppress indent in textarea.
-        %textarea.form-control.ssh-public-key{name: 'sshPublicKey', placeholder: 'ssh-rsa XXXXXXX...'}=user['sshPublicKey'].join("\n")
+        %textarea.form-control.ssh-public-key{name: 'sshPublicKey', placeholder: 'ssh-rsa XXXXXXX...'}= user['sshPublicKey'].join("\n")
     %div.row
       %div.col-sm-2.col-xs-12
         備考

--- a/views/edit.haml
+++ b/views/edit.haml
@@ -96,8 +96,8 @@
       %div.col-sm-2.col-xs-12
         SSH 公開鍵
       %div.col-sm-10.col-xs-12
-        %textarea.form-control.ssh-public-key{name: 'sshPublicKey', placeholder: 'ssh-rsa XXXXXXX...'}
-          = user['sshPublicKey'].join("\n")
+        / Content must be on the same line to suppress indent in textarea.
+        %textarea.form-control.ssh-public-key{name: 'sshPublicKey', placeholder: 'ssh-rsa XXXXXXX...'}=user['sshPublicKey'].join("\n")
     %div.row
       %div.col-sm-2.col-xs-12
         備考


### PR DESCRIPTION
- textarea では自動で preserve される
  - この時、 `=` が同じ行にないと textarea 内と認識されなかった

http://haml.info/docs/yardoc/file.FAQ.html#how-do-i-stop-haml-from-indenting-the-contents-of-my-pre-and-textarea-tags