### PR TITLE
Login name blacklist

### DIFF
--- a/config/guildbook.yml.example
+++ b/config/guildbook.yml.example
@@ -1,3 +1,4 @@
+# -*- yaml -*-
 development:
   assets_uri: '/members/assets'
   ldap_uri:
@@ -11,3 +12,7 @@ development:
   ui:
     default_sort_keys: -uidNumber
   samba_domain_name: KMC
+
+  adduser:
+    login_blacklist:
+      - [root, daemon, bin, sys, sync, games, man, mail, news, uucp, proxy, backup, list, irc, gnats, nobody]  # Debian default sysusers

--- a/lib/plugins/adduser_plugin.rb
+++ b/lib/plugins/adduser_plugin.rb
@@ -122,17 +122,18 @@ module GuildBook
     end
 
     def check_uid_unique(uid)
+      blacklist = settings.adduser['login_blacklist'].flatten
+      if blacklist.include?(uid)
+        raise UserRepo::Error, "Login name '#{uid}' is blacklisted"
+      end
+
+      if File.exist?(File.join('/home', uid))
+        raise UserRepo::Error, "Login name '#{uid}' found in /home"
+      end
+
       if user_repo.do_search(Net::LDAP::Filter.eq('uid', uid)).first
-        raise UserRepo::Error, uid + " already found in LDAP"
+        raise UserRepo::Error, "Login name '#{uid}' found in LDAP"
       end
-      if File.exist?('/home/' + uid)
-        raise UserRepo::Error, uid + " already found in /home"
-      end
-      open('/etc/aliases') { |io|
-        if io.each_line.find {|line| line.start_with?("#{uid}:")}
-          raise UserRepo::Error, uid + " already found in /etc/aliases"
-        end
-      }
     end
   end
 end


### PR DESCRIPTION
ユーザ作成時に/etc/aliases読むのをやめて，設定ファイルにあるブラックリストを使うようにします