### PR TITLE
type=telだとiOSでハイフンが入力できない

### DIFF
--- a/views/edit.haml
+++ b/views/edit.haml
@@ -46,7 +46,7 @@
         電話番号
         %span.form-required *
       %div.form-group.col-md-5.col-sm-12
-        - input_userattr user, 'telephoneNumber', type: :tel, required: true, placeholder: '090-XXXX-YYYY', pattern: '\d+-\d+-\d+'
+        - input_userattr user, 'telephoneNumber', type: :text, required: true, placeholder: '090-XXXX-YYYY', pattern: '\d+-\d+-\d+'
     %div.form-row
       %div.form-group.col-md-2.col-sm-12
         住所


### PR DESCRIPTION
とのこと