### PR TITLE
京都大学関係者以外が任意で入力可能な学年欄を追加

### DIFF
--- a/javascript/packs/app.ts
+++ b/javascript/packs/app.ts
@@ -219,25 +219,13 @@ document.addEventListener('DOMContentLoaded', () => {
           div.hidden = isKUMember;
         })
         form.querySelectorAll<HTMLInputElement>('form div.is-ku:not(.not-required) .form-control, form div.is-ku:not(.not-required) .form-select').forEach(input => {
-          if (isKUMember) {
-            input.setAttribute("required", "true");
-          } else {
-            input.removeAttribute("required");
-          }
+          input.required = isKUMember;
         })
         form.querySelectorAll<HTMLInputElement>('form div.grade .form-control, form div.grade .form-select').forEach(input => {
-          if (isKUMember) {
-            input.setAttribute("required", "true");
-          } else {
-            input.removeAttribute("required");
-          }
+          input.required = isKUMember;
         })
         form.querySelectorAll<HTMLInputElement>('form div.not-ku:not(.not-required) .form-control, form div.not-ku:not(.not-required) .form-select').forEach(input => {
-          if (!isKUMember) {
-            input.setAttribute("required", "true");
-          } else {
-            input.removeAttribute("required");
-          }
+          input.required = !isKUMember;
         })
       }
       rewrite();

--- a/javascript/packs/app.ts
+++ b/javascript/packs/app.ts
@@ -219,10 +219,25 @@ document.addEventListener('DOMContentLoaded', () => {
           div.hidden = isKUMember;
         })
         form.querySelectorAll<HTMLInputElement>('form div.is-ku:not(.not-required) .form-control, form div.is-ku:not(.not-required) .form-select').forEach(input => {
-          input.required=isKUMember;
+          if (isKUMember) {
+            input.setAttribute("required", "true");
+          } else {
+            input.removeAttribute("required");
+          }
+        })
+        form.querySelectorAll<HTMLInputElement>('form div.grade .form-control, form div.grade .form-select').forEach(input => {
+          if (isKUMember) {
+            input.setAttribute("required", "true");
+          } else {
+            input.removeAttribute("required");
+          }
         })
         form.querySelectorAll<HTMLInputElement>('form div.not-ku:not(.not-required) .form-control, form div.not-ku:not(.not-required) .form-select').forEach(input => {
-          input.required=!isKUMember;
+          if (!isKUMember) {
+            input.setAttribute("required", "true");
+          } else {
+            input.removeAttribute("required");
+          }
         })
       }
       rewrite();

--- a/views/edit.haml
+++ b/views/edit.haml
@@ -98,29 +98,29 @@
           %span.form-required *
           %div
           - select_userattr user, 'x-kmc-IsKUMember', {"TRUE" => "京都大学", "FALSE" => "その他"} , false, id: 'edit-is-kyoto-university'
+      %div.col-12.col-lg-7.mb-2.not-ku.not-required{hidden: "hidden"}
+        %label{for: 'edit-university-department'}
+          所属組織・学部・学科
+        %div
+          - input_userattr user, 'x-kmc-UniversityDepartment', id: 'edit-university-department', placeholder: '千葉電波大学理学部, 社会人'
       %div.col-12.col-lg-4.mb-2.is-ku
         %label{for: 'edit-ku-department'}
           学部・学科
           %span.form-required *京大所属者は必須
         %div
           - select_userattr user, 'x-kmc-KUDepartment', ku_departments, true, id: 'edit-ku-department', required: true
-      %div.col-12.col-lg-4.mb-2.is-ku
+      %div.col-12.col-lg-3.mb-2.is-ku
         %label{for: 'edit-ku-student-number'}
           学生番号
           %span.form-required *京大所属者は必須
         %div
           - input_userattr user, 'x-kmc-KUStudentNumber', id: 'edit-ku-student-number', type: :text, required: true, placeholder: 'XXXX-YY-ZZZZ', pattern: '[A-Z0-9]+-[A-Z0-9]+-[A-Z0-9]+'
-      %div.col-12.col-lg-2.mb-2.is-ku
+      %div.col-12.col-lg-3.mb-2.grade.not-required
         %label{for: 'edit-university-status'}
           学年
           %span.form-required *京大所属者は必須
         %div
           - input_userattr user, 'x-kmc-UniversityStatus', id: 'edit-university-status', required: true, placeholder: '1, M2, D3, 教授'
-      %div.col-12.col-lg-10.mb-2.not-ku.not-required{hidden: "hidden"}
-        %label{for: 'edit-university-department'}
-          所属組織・学部・学科
-        %div
-          - input_userattr user, 'x-kmc-UniversityDepartment', id: 'edit-university-department', placeholder: '千葉電波大学理学部, 社会人'
     %div.row
       %div.col-12.col-lg-6.mb-2
         %label{for: 'edit-university-matric-year'}


### PR DESCRIPTION
背景: 京都大学所属者以外が名簿を編集すると、現在は学年欄を入力できない状況です。それによりWiki用の名簿 (checklist plugin) を出力した際に、学生ではなくOBと誤認識されようになっていました。

そこで、この Pull Request においては、部員名簿編集時に、所属にかかわらず学年欄 `x-kmc-UniversityStatus` を表示して入力できるように変更しました。
また、表示のバランスをとるために入力欄のサイズ変更と所属組織欄と学年との順序入れ替えを行いました

ここで、学年欄の挙動は以下のようになっています。

- 京都大学を選択したとき: 学年欄は必須項目
- その他を選択したとき: 学年欄が任意項目